### PR TITLE
Fix git.io link

### DIFF
--- a/meetups/20160126-meetup-40.md
+++ b/meetups/20160126-meetup-40.md
@@ -1,7 +1,7 @@
 #### Thessaloniki Ruby Meetup 40
 
-Share   | http://git.io/thessrb-40
-------- | ------------------------
+Share   | https://git.io/vz8fJ
+------- | --------------------
 When    | Tuesday 26 January 2016 @ 19:00 - 21:00
 Twitter | [#thessrb](http://bit.ly/1VCOXGU)
 Where   | City College, Auditorium room, Leontos Sofou 3, **5th Floor**


### PR DESCRIPTION
For some weird reason, I couldn't create a git.io link with a custom code.