### PR TITLE
Introduce a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+Prepare the announcement:
+
+- [ ] Find a date and a place
+- [ ] Rename `meetup-NN.md` to `YYYYMMDD-meetup-NN.md` in the `meetups` folder
+- [ ] Fill in a nice title
+- [ ] Fill in a summary of the presentation
+- [ ] Fill in the name of the speaker as a link to their GitHub account
+- [ ] Fill in a short biography of the speaker
+- [ ] Link resources about the main topics under "Notes" as a bullet list
+- [ ] Prepare video announcement
+- [ ] Create the meetup.com event
+- [ ] Create the Facebook event
+- [ ] Add the links here
+- [ ] When all above are checked off, merge this
+- [ ] Create a `thessrb-NN` git.io URL with code to `YYYYMMDD-meetup-NN.md`
+- [ ] Add event to [SKGTech Calendar](http://skgtech.io/submit-event/)
+- [ ] Go crazy announcing the meet-up everywhere


### PR DESCRIPTION
The pull request template has the following content:

```
Prepare the announcement:

- [ ] Find a date and a place
- [ ] Rename `meetup-NN.md` to `YYYYMMDD-meetup-NN.md` in the `meetups` folder
- [ ] Fill in a nice title
- [ ] Fill in a summary of the presentation
- [ ] Fill in the name of the speaker as a link to their GitHub account
- [ ] Fill in a short biography of the speaker
- [ ] Link resources about the main topics under "Notes" as a bullet list
- [ ] Prepare video announcement
- [ ] Create the meetup.com event
- [ ] Create the Facebook event
- [ ] Add the links here
- [ ] When all above are checked off, merge this
- [ ] Create a `thessrb-NN` git.io URL with code to `YYYYMMDD-meetup-NN.md`
- [ ] Add event to [SKGTech Calendar](http://skgtech.io/submit-event/)
- [ ] Go crazy announcing the meet-up everywhere
```

Since most pull requests in this repository is about preparing a meet-up.
